### PR TITLE
🩹 fix: DB テーブル learning_contents に CREATE TRIGGER update_learning_contents_updated_at を追加

### DIFF
--- a/apps/dokuha-roadmap-backend/drizzle/0000_open_starhawk.sql
+++ b/apps/dokuha-roadmap-backend/drizzle/0000_open_starhawk.sql
@@ -11,6 +11,7 @@ CREATE TABLE `users` (
 CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);
 
 -- NOTE: 以下のTRIGGERは、$onUpdate でうまく作成できず挫折したため手動で作成している
+-- まだないっぽい：https://github.com/drizzle-team/drizzle-orm/issues/843
 CREATE TRIGGER `update_users_updated_at`
 AFTER UPDATE ON `users` FOR EACH ROW
 BEGIN

--- a/apps/dokuha-roadmap-backend/drizzle/0001_exotic_adam_warlock.sql
+++ b/apps/dokuha-roadmap-backend/drizzle/0001_exotic_adam_warlock.sql
@@ -9,3 +9,11 @@ CREATE TABLE `learning_contents` (
 	`updated_at` text DEFAULT CURRENT_TIMESTAMP,
 	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
 );
+
+-- NOTE: 以下のTRIGGERは、$onUpdate でうまく作成できず挫折したため手動で作成している
+-- まだないっぽい：https://github.com/drizzle-team/drizzle-orm/issues/843
+CREATE TRIGGER `update_learning_contents_updated_at`
+AFTER UPDATE ON `learning_contents` FOR EACH ROW
+BEGIN
+    UPDATE `learning_contents` SET `updated_at` = CURRENT_TIMESTAMP WHERE `id` = OLD.`id`;
+END;

--- a/apps/dokuha-roadmap-backend/src/index.ts
+++ b/apps/dokuha-roadmap-backend/src/index.ts
@@ -238,7 +238,6 @@ app.put("/learning-contents/:id", async (c) => {
     await db.update(learningContents)
       .set({
         ...validatedData,
-        updatedAt: sql`CURRENT_TIMESTAMP`,
       })
       .where(eq(learningContents.id, id));
 


### PR DESCRIPTION
## やったこと

<!-- やったことの概要を端的に書く。細かい話はコードにセルフコメントする。 -->

- なるべくアプリケーションコードは減らしたいので、DB で更新できるものは DB に押し付ける

## ドキュメント

<!-- Notion のチケットや Figma のデザイン、関連する Slack での議論などの URL を貼る。 -->

- 


## 動作確認

<!-- チェックボックス or 成果物の画像や動画を貼る。 -->

- [ ] 動作検証不要（アプリケーションの変更無し、など）
- [ ] ツールで動作検証できる
- [ ] ツールで動作検証できない（動作確認の方法を記載した）
  - [ ] PUT でlearning_contentsを更新した時、updated_atが更新されていることを確認

<!-- ツールで動作検証できない場合は動作検証の方法を記載してください -->

- 

## 備考

<!-- その他何かあれば。 -->

- 
