### PR TITLE
seed data追加

### DIFF
--- a/apps/dokuha-roadmap-backend/README.md
+++ b/apps/dokuha-roadmap-backend/README.md
@@ -1,22 +1,27 @@
 # Dokuha Roadmap Backend
 
 ## Getting Started
+
 ```txt
 pnpm install
 pnpm run dev
 ```
 
 ### migration
+
 ```txt
 pnpm local:migration
+pnpm seed
 ```
 
-### 開発中に GUI でDBを確認したい場合
+### 開発中に GUI で DB を確認したい場合
+
 ```txt
 pnpm studio
 ```
 
 ## Deploying
+
 ```txt
 pnpm run deploy
 ```
@@ -31,5 +36,5 @@ Pass the `CloudflareBindings` as generics when instantiation `Hono`:
 
 ```ts
 // src/index.ts
-const app = new Hono<{ Bindings: CloudflareBindings }>()
+const app = new Hono<{ Bindings: CloudflareBindings }>();
 ```

--- a/apps/dokuha-roadmap-backend/drizzle.config.ts
+++ b/apps/dokuha-roadmap-backend/drizzle.config.ts
@@ -5,7 +5,7 @@ export default {
   out: "./drizzle",
   dialect: "sqlite",
   dbCredentials: {
-    // TODO: 確かめていないが、以下のファイル名を直接指定するやり方だとチームメンバーがそれぞれ手動でいじる必要がある可能性があるため、必要に応じて修正する
-    url: "./.wrangler/state/v3/d1/miniflare-D1DatabaseObject/1b52ece63023367627078964169e02f25e79862c5fb40a72236be4f7aebd8b9e.sqlite",
+    // NOTE: 開発用の D1_PRODUCTION_DB_ID という命名でローカル DB を作成した場合、以下の名前で .sqlite ファイルが作成される
+    url: "./.wrangler/state/v3/d1/miniflare-D1DatabaseObject/452ecafc4500a35827af44758854d2db3122cb82afaa35f19f9834426ee79073.sqlite",
   },
 } satisfies Config;

--- a/apps/dokuha-roadmap-backend/drizzle.config.ts
+++ b/apps/dokuha-roadmap-backend/drizzle.config.ts
@@ -5,7 +5,7 @@ export default {
   out: "./drizzle",
   dialect: "sqlite",
   dbCredentials: {
-    // NOTE: 開発用の D1_PRODUCTION_DB_ID という命名でローカル DB を作成した場合、以下の名前で .sqlite ファイルが作成される
+    // NOTE: 開発用の D1_PRODUCTION_DB_ID という id でローカル DB を作成した場合、以下の名前で .sqlite ファイルが作成される
     url: "./.wrangler/state/v3/d1/miniflare-D1DatabaseObject/452ecafc4500a35827af44758854d2db3122cb82afaa35f19f9834426ee79073.sqlite",
   },
 } satisfies Config;

--- a/apps/dokuha-roadmap-backend/package.json
+++ b/apps/dokuha-roadmap-backend/package.json
@@ -8,7 +8,8 @@
     "generate:custom": "drizzle-kit generate --custom",
     "local:migration": "wrangler d1 migrations apply prod-dokuha-roadmap --local",
     "remote:migration": "wrangler d1 migrations apply prod-dokuha-roadmap --remote",
-    "studio": "npx drizzle-kit studio"
+    "studio": "npx drizzle-kit studio",
+    "seed": "wrangler d1 execute prod-dokuha-roadmap --local --file=seed.sql"
   },
   "dependencies": {
     "drizzle-orm": "^0.43.1",

--- a/apps/dokuha-roadmap-backend/seed.sql
+++ b/apps/dokuha-roadmap-backend/seed.sql
@@ -1,0 +1,45 @@
+INSERT INTO users (
+  id,
+  nickname,
+  email,
+  password,
+  reading_mission
+) VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  'テスト太郎',
+  'john@example.com',
+  'password123',
+  'Read more books'
+);
+
+INSERT INTO learning_contents (
+  id,
+  user_id,
+  title,
+  total_page,
+  current_page,
+  note
+) VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  'プログラミング入門1',
+  300,
+  1,
+  '初めてのプログラミング学習1'
+);
+
+INSERT INTO learning_contents (
+  id,
+  user_id,
+  title,
+  total_page,
+  current_page,
+  note
+) VALUES (
+  '00000000-0000-0000-0000-000000000002',
+  '00000000-0000-0000-0000-000000000001',
+  'プログラミング入門2',
+  300,
+  1,
+  '初めてのプログラミング学習2'
+);

--- a/apps/dokuha-roadmap-backend/seed.sql
+++ b/apps/dokuha-roadmap-backend/seed.sql
@@ -26,16 +26,7 @@ INSERT INTO learning_contents (
   300,
   1,
   '初めてのプログラミング学習1'
-);
-
-INSERT INTO learning_contents (
-  id,
-  user_id,
-  title,
-  total_page,
-  current_page,
-  note
-) VALUES (
+),(
   '00000000-0000-0000-0000-000000000002',
   '00000000-0000-0000-0000-000000000001',
   'プログラミング入門2',

--- a/apps/dokuha-roadmap-backend/wrangler.jsonc
+++ b/apps/dokuha-roadmap-backend/wrangler.jsonc
@@ -24,7 +24,7 @@
   "d1_databases": [
     {
       "binding": "productionDB",
-      "database_name": "D1_PRODUCTION_DB_NAME",
+      "database_name": "prod-dokuha-roadmap",
       "database_id": "D1_PRODUCTION_DB_ID",
       "migrations_dir": "drizzle"
     }


### PR DESCRIPTION
## やったこと

<!-- やったことの概要を端的に書く。細かい話はコードにセルフコメントする。 -->

- コマンドでユーザーデータと書籍データを追加できるようにした。
  - 認証機能ができるまで、 user_id は全て 000~~~1 の uuid を利用して開発すると楽です。

## ドキュメント

<!-- Notion のチケットや Figma のデザイン、関連する Slack での議論などの URL を貼る。 -->

- 


## 動作確認
<img width="1393" alt="スクリーンショット 2025-05-08 22 49 51" src="https://github.com/user-attachments/assets/10b25de7-b384-4775-8206-0361880ca35e" />

<!-- チェックボックス or 成果物の画像や動画を貼る。 -->

- [ ] 動作検証不要（アプリケーションの変更無し、など）
- [ ] ツールで動作検証できる
- [x] ツールで動作検証できない（動作確認の方法を記載した）
  - [x] README.md に記載の手順でコマンドを実行すると、テスト用のデータがiNSERTされる

<!-- ツールで動作検証できない場合は動作検証の方法を記載してください -->

- 

## 備考

<!-- その他何かあれば。 -->

- 
